### PR TITLE
Fix x64 build recipes of gdb and binutils for OS X Mavericks

### DIFF
--- a/arm-elf-gcc.rb
+++ b/arm-elf-gcc.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class ArmElfGcc < Formula
   homepage 'http://gcc.gnu.org'
-  url 'http://ftpmirror.gnu.org/gcc/gcc-4.7.2/gcc-4.7.2.tar.bz2'
-  mirror 'http://ftp.gnu.org/gnu/gcc/gcc-4.7.2/gcc-4.7.2.tar.bz2'
-  sha1 'a464ba0f26eef24c29bcd1e7489421117fb9ee35'
+  url 'http://ftpmirror.gnu.org/gcc/gcc-4.8.0/gcc-4.8.0.tar.bz2'
+  mirror 'http://ftp.gnu.org/gnu/gcc/gcc-4.8.0/gcc-4.8.0.tar.bz2'
+  sha1 'b4ee6e9bdebc65223f95067d0cc1a634b59dad72'
 
   depends_on 'gmp'
   depends_on 'libmpc'

--- a/arm-elf-gdb.rb
+++ b/arm-elf-gdb.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class ArmElfGdb < Formula
   homepage 'http://gcc.gnu.org'
-  url 'http://ftp.gnu.org/gnu/gdb/gdb-7.5.tar.bz2'
-  sha1 '79b61152813e5730fa670c89e5fc3c04b670b02c'
+  url 'http://ftp.gnu.org/gnu/gdb/gdb-7.6.tar.bz2'
+  sha1 'b64095579a20e011beeaa5b264fe23a9606ee40f'
 
   depends_on 'arm-elf-binutils'
   depends_on 'arm-elf-gcc'

--- a/i586-elf-gcc.rb
+++ b/i586-elf-gcc.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class I586ElfGcc < Formula
   homepage 'http://gcc.gnu.org'
-  url 'http://ftpmirror.gnu.org/gcc/gcc-4.7.2/gcc-4.7.2.tar.bz2'
-  mirror 'http://ftp.gnu.org/gnu/gcc/gcc-4.7.2/gcc-4.7.2.tar.bz2'
-  sha1 'a464ba0f26eef24c29bcd1e7489421117fb9ee35'
+  url 'http://ftpmirror.gnu.org/gcc/gcc-4.8.0/gcc-4.8.0.tar.bz2'
+  mirror 'http://ftp.gnu.org/gnu/gcc/gcc-4.8.0/gcc-4.8.0.tar.bz2'
+  sha1 'b4ee6e9bdebc65223f95067d0cc1a634b59dad72'
 
   depends_on 'gmp'
   depends_on 'libmpc'

--- a/i586-elf-gdb.rb
+++ b/i586-elf-gdb.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class I586ElfGdb < Formula
   homepage 'http://gcc.gnu.org'
-  url 'http://ftp.gnu.org/gnu/gdb/gdb-7.5.tar.bz2'
-  sha1 '79b61152813e5730fa670c89e5fc3c04b670b02c'
+  url 'http://ftp.gnu.org/gnu/gdb/gdb-7.6.tar.bz2'
+  sha1 'b64095579a20e011beeaa5b264fe23a9606ee40f'
 
   depends_on 'i586-elf-binutils'
   depends_on 'i586-elf-gcc'

--- a/x64-elf-binutils.rb
+++ b/x64-elf-binutils.rb
@@ -8,6 +8,7 @@ class X64ElfBinutils < Formula
   depends_on 'apple-gcc42' => :build
 
   def install
+    ENV['CFLAGS']="-Wno-error=deprecated-declarations"
     ENV['CC'] = '/usr/local/bin/gcc-4.2'
     ENV['CXX'] = '/usr/local/bin/g++-4.2'
     ENV['CPP'] = '/usr/local/bin/cpp-4.2'

--- a/x64-elf-gcc.rb
+++ b/x64-elf-gcc.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class X64ElfGcc < Formula
   homepage 'http://gcc.gnu.org'
-  url 'http://ftpmirror.gnu.org/gcc/gcc-4.7.2/gcc-4.7.2.tar.bz2'
-  mirror 'http://ftp.gnu.org/gnu/gcc/gcc-4.7.2/gcc-4.7.2.tar.bz2'
-  sha1 'a464ba0f26eef24c29bcd1e7489421117fb9ee35'
+  url 'http://ftpmirror.gnu.org/gcc/gcc-4.8.0/gcc-4.8.0.tar.bz2'
+  mirror 'http://ftp.gnu.org/gnu/gcc/gcc-4.8.0/gcc-4.8.0.tar.bz2'
+  sha1 'b4ee6e9bdebc65223f95067d0cc1a634b59dad72'
 
   depends_on 'gmp'
   depends_on 'libmpc'

--- a/x64-elf-gdb.rb
+++ b/x64-elf-gdb.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class X64ElfGdb < Formula
   homepage 'http://gcc.gnu.org'
-  url 'http://ftp.gnu.org/gnu/gdb/gdb-7.5.tar.bz2'
-  sha1 '79b61152813e5730fa670c89e5fc3c04b670b02c'
+  url 'http://ftp.gnu.org/gnu/gdb/gdb-7.6.tar.bz2'
+  sha1 'b64095579a20e011beeaa5b264fe23a9606ee40f'
 
   depends_on 'x64-elf-binutils'
   depends_on 'x64-elf-gcc'
@@ -57,4 +57,3 @@ index 1c9367d..5940ce2 100644
 
    /* Save the size of the packet sent to us by the target.  It is used
       as a heuristic when determining the max size of packets that the
-

--- a/x64-elf-gdb.rb
+++ b/x64-elf-gdb.rb
@@ -9,6 +9,7 @@ class X64ElfGdb < Formula
   depends_on 'x64-elf-gcc'
 
   def install
+    ENV['CFLAGS']="-Wno-error=deprecated-declarations"
     ENV['CC'] = '/usr/local/bin/gcc-4.2'
     ENV['CXX'] = '/usr/local/bin/g++-4.2'
     ENV['CPP'] = '/usr/local/bin/cpp-4.2'


### PR DESCRIPTION
This pull request also contains sevkis commit which uses newer versions of gcc and gdb. Works well.
